### PR TITLE
add typescript typing to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.22.0",
   "description": "Get a logger. Any logger.",
   "main": "anylogger.js",
+  "types": "anylogger.d.ts",
   "files": [
     "anylogger.js",
     "anylogger.d.ts",


### PR DESCRIPTION
The typings need to be added to the package.json for typescript projects to be able to use them.