### PR TITLE
Fix TypeScript type declarations to use accurate export style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /anylogger.umd.js
 /anylogger.cjs.js
 /anylogger.iife.js
+/test.js

--- a/anylogger.d.ts
+++ b/anylogger.d.ts
@@ -1,88 +1,94 @@
-export type BaseLevels = {
-  error: 1,
-  warn: 2,
-  info: 3,
-  log: 4,
-  debug: 5,
-  trace: 6,
+declare namespace anylogger {
+  // NOTE: All types in this scope are implicitly exported.
+
+  type BaseLevels = {
+    error: 1,
+    warn: 2,
+    info: 3,
+    log: 4,
+    debug: 5,
+    trace: 6,
+  }
+
+  interface BaseLogger<L extends BaseLevels = BaseLevels> {
+    /**
+     * The name of this logger.
+     */
+    name: string
+
+    (level: keyof L, message?: any, ...args: any[]): void
+    (message?: any, ...args: any[]): void
+
+    error(message?: any, ...args: any[]): void
+    warn(message?: any, ...args: any[]): void
+    info(message?: any, ...args: any[]): void
+    log(message?: any, ...args: any[]): void
+    debug(message?: any, ...args: any[]): void
+    trace(message?: any, ...args: any[]): void
+    enabledFor(level: keyof L): boolean
+  }
+
+  type Logger<L extends BaseLevels = BaseLevels> = BaseLogger<L> & {
+    [P in keyof Omit<L, keyof BaseLevels>]: (message?: any, ...args: any[]) => void
+  }
+
+  interface AnyLogger<L extends BaseLevels, T extends BaseLogger<L> = Logger<L>> {
+    /**
+     * Returns an object containing all loggers created so far, keyed by name.
+     */
+    (): { [name: string]: T }
+
+    /**
+     * @param name The name of the new logger.
+     * @param config An optional config object.
+     * @returns A logger with the given `name` and `config`.
+     */
+    (name: string, config?: object | undefined): T
+
+    /**
+     * An object containing a mapping of level names to level values.
+     */
+    levels: L & { [name: string]: number }
+
+    /**
+     * Creates a new logger function that calls `anylogger.log` when invoked.
+     *
+     * @param name The name of the new logger.
+     * @param config An optional config object.
+     * @returns A new logger function with the given `name`.
+     */
+    new(name: string, config?: object | undefined): T
+
+    /**
+     * The log function used by `anylogger.new`.
+     *
+     * @param name The name of the logger to use
+     * @param level The log level.
+     * @param message The (formatted) message or any data to log.
+     * @param [params] Additional log (formatting) arguments.
+     */
+    log(name: string, level: keyof L, message?: any, ...args: any[]): void
+
+    /**
+     * The log function used by `anylogger.new`.
+     *
+     * @param name The name of the logger to use
+     * @param args The log arguments.
+     * @param message The (formatted) message or any data to log.
+     * @param [params] Additional log (formatting) arguments.
+     */
+    log(name: string, message?: any, ...args: any[]): void
+
+    /**
+     * @param logger The logger that should be (re-)extended.
+     * @return The logger that was given, extended.
+     */
+    ext(logger: T): T
+  }
 }
 
-export interface BaseLogger<L extends BaseLevels = BaseLevels> {
-  /**
-   * The name of this logger.
-   */
-  name: string
+declare const anylogger: anylogger.AnyLogger<anylogger.BaseLevels>
 
-  (level: keyof L, message?: any, ...args: any[]): void
-  (message?: any, ...args: any[]): void
-
-  error(message?: any, ...args: any[]): void
-  warn(message?: any, ...args: any[]): void
-  info(message?: any, ...args: any[]): void
-  log(message?: any, ...args: any[]): void
-  debug(message?: any, ...args: any[]): void
-  trace(message?: any, ...args: any[]): void
-  enabledFor(level: keyof L): boolean
-}
-
-export type Logger<L extends BaseLevels = BaseLevels> = BaseLogger<L> & {
-  [P in keyof Omit<L, keyof BaseLevels>]: (message?: any, ...args: any[]) => void
-}
-
-export interface AnyLogger<L extends BaseLevels, T extends BaseLogger<L> = Logger<L>> {
-  /**
-   * Returns an object containing all loggers created so far, keyed by name.
-   */
-  (): { [name: string]: T }
-
-  /**
-   * @param name The name of the new logger.
-   * @param config An optional config object.
-   * @returns A logger with the given `name` and `config`.
-   */
-  (name: string, config?: object | undefined): T
-
-  /**
-   * An object containing a mapping of level names to level values.
-   */
-  levels: L & { [name: string]: number }
-
-  /**
-   * Creates a new logger function that calls `anylogger.log` when invoked.
-   *
-   * @param name The name of the new logger.
-   * @param config An optional config object.
-   * @returns A new logger function with the given `name`.
-   */
-  new(name: string, config?: object | undefined): T
-
-  /**
-   * The log function used by `anylogger.new`.
-   *
-   * @param name The name of the logger to use
-   * @param level The log level.
-   * @param message The (formatted) message or any data to log.
-   * @param [params] Additional log (formatting) arguments.
-   */
-  log(name: string, level: keyof L, message?: any, ...args: any[]): void
-  
-  /**
-   * The log function used by `anylogger.new`.
-   *
-   * @param name The name of the logger to use
-   * @param args The log arguments.
-   * @param message The (formatted) message or any data to log.
-   * @param [params] Additional log (formatting) arguments.
-   */
-  log(name: string, message?: any, ...args: any[]): void
-
-  /**
-   * @param logger The logger that should be (re-)extended.
-   * @return The logger that was given, extended.
-   */
-  ext(logger: T): T
-}
-
-declare const anylogger: AnyLogger<BaseLevels>
-
-export default anylogger
+// NOTE: Do not rewrite it into `export default` unless anylogger's `main`
+// entrypoint actually exports `default`.
+export = anylogger

--- a/anylogger.d.ts
+++ b/anylogger.d.ts
@@ -1,4 +1,6 @@
 declare namespace anylogger {
+  // vs export as namespace anylogger;  ??
+
   // NOTE: All types in this scope are implicitly exported.
 
   type BaseLevels = {
@@ -87,8 +89,10 @@ declare namespace anylogger {
   }
 }
 
-declare const anylogger: anylogger.AnyLogger
+declare const anylogger: AnyLogger
 
 // NOTE: Do not rewrite it into `export default` unless anylogger's `main`
 // entrypoint actually exports `default`.
 export = anylogger
+export default anylogger
+// please verify in anylogger.js that we now export to 'default' as well...

--- a/anylogger.d.ts
+++ b/anylogger.d.ts
@@ -32,7 +32,7 @@ declare namespace anylogger {
     [P in keyof Omit<L, keyof BaseLevels>]: (message?: any, ...args: any[]) => void
   }
 
-  interface AnyLogger<L extends BaseLevels, T extends BaseLogger<L> = Logger<L>> {
+  interface AnyLogger<L extends BaseLevels = BaseLevels, T extends BaseLogger<L> = Logger<L>> {
     /**
      * Returns an object containing all loggers created so far, keyed by name.
      */
@@ -87,7 +87,7 @@ declare namespace anylogger {
   }
 }
 
-declare const anylogger: anylogger.AnyLogger<anylogger.BaseLevels>
+declare const anylogger: anylogger.AnyLogger
 
 // NOTE: Do not rewrite it into `export default` unless anylogger's `main`
 // entrypoint actually exports `default`.

--- a/anylogger.js
+++ b/anylogger.js
@@ -118,5 +118,6 @@ anylogger.ext = function(logger) {
   return logger
 }
 
+anylogger.default = anylogger
 
 export default anylogger

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,11 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@types/debug": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
+      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -828,6 +833,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "minify": "cross-env NODE_ENV=production node build.js minify",
     "package": "cross-env NODE_ENV=production rollup -c",
     "prepare": "npm run build",
-    "test": "npm run package -s && mocha anylogger.spec.js"
+    "test": "npm run package -s && tsc && node ./test.js && mocha anylogger.spec.js"
   },
   "author": "Stijn de Witt",
   "license": "MIT",
@@ -41,6 +41,7 @@
     "mocha": "^8.2.1",
     "rollup": "^2.35.1",
     "sinon": "^9.2.2",
+    "typescript": "^4.1.3",
     "uglify-js": "^3.12.3"
   },
   "keywords": [

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,5 @@
+// import anylogger = require('./')
+import anylogger from './'
+
+const log = anylogger('test')
+log('test')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,69 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  }
+}


### PR DESCRIPTION
The current way is inaccurate because `anylogger.cjs.js`, the `main`
entrypoint, uses CommonJS and does not export `default`. Thus it works
only when the library consumer enables `esModuleInterop`. Most devs have
it enabled, but this option is just a workaround for badly written
type declarations.

https://github.com/DefinitelyTyped/DefinitelyTyped#a-package-uses-export--but-i-prefer-to-use-default-imports-can-i-change-export--to-export-default:

> For an npm package, export = is accurate if `node -p 'require("foo")'`
> works to import a module, and export default is accurate if
> `node -p 'require("foo").default'` works to import a module.